### PR TITLE
bug fix in LatticeGenotypePhenotypeMap.__init__. Wrong order of param…

### DIFF
--- a/latticegpm/gpm.py
+++ b/latticegpm/gpm.py
@@ -75,7 +75,7 @@ class LatticeGenotypePhenotypeMap(GenotypePhenotypeMap):
         **kwargs):
 
         # Get list of genotypes
-        genotypes = mutations_to_genotypes(wildtype, mutations)
+        genotypes = mutations_to_genotypes(mutations, wildtype)
 
         # Calculate lattice proteins.
         self.latticeproteins = LatticeProteins(


### PR DESCRIPTION
bug fix in LatticeGenotypePhenotypeMap.__init__(). Wrong order of parameters in mutations_to_genotypes() call. Should be (mutations, wildtype) not (wildtype, mutations).